### PR TITLE
Add -Pn flag for disabling host discovery

### DIFF
--- a/bashscan.sh
+++ b/bashscan.sh
@@ -370,9 +370,11 @@ grepable_output(){
 normal_output(){
 	printf "Scan report for %s (%s):\n" $name $host
 
+	# If we have a latency value, host is up
 	if [[ -n "$latency" ]]; then
 		printf "Host is up (%ss latency)\n" $latency
-	else
+	# Only report down if we haven't disabled ping
+	elif [[ "$DO_PING" = true ]]; then
 		printf "Host seems down\n"
 	fi
 
@@ -558,7 +560,13 @@ main(){
 
 	for host in ${LIVEHOSTS[@]}; do
 		name=$(revdns $host)
-		latency="$(latency $host)"
+		# Usually, the only reason ping will be disabled is because
+		# ICMP is being dropped/blocked. In this case, our latency
+		# method won't work either, so only attempt latency measure
+		# if we can ping. 
+		if [[ "$DO_PING" = true ]]; then
+			latency="$(latency $host)"
+		fi
 		portscan $host
 
 		# If we specify -o flag, only print results if one or more

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -6,7 +6,7 @@
 PARSED_ARGUMENTS=$(getopt -n $PROGNAME \
 	-a \
 	-o be:hop:rt:T:v \
-	-l banner,exclude:,help,iL:,xL:,oG:,oN:,open,ports:,root,timing:,top-ports:,version \
+	-l banner,exclude:,help,iL:,xL:,oG:,oN:,Pn,open,ports:,root,timing:,top-ports:,version \
 	-- "$@")
 VALID_ARGUMENTS=$?
 
@@ -31,6 +31,7 @@ while [ $# -gt 0 ]; do
 		-~  | --xL          ) x_file="$2"               ; shift 2 ;;
 		-~  | --oG          ) g_file="$2"               ; shift 2 ;; 
 		-~  | --oN          ) n_file="$2"               ; shift 2 ;;
+		-~  | --Pn          ) DO_PING=false             ; shift 1 ;;
 		-o  | --open        ) OPEN=true                 ; shift 1 ;;
 		-p  | --ports       ) ports="$2"                ; shift 2 ;;
 		-t  | --top-ports   ) TOP_PORTS="$2"            ; shift 2 ;;

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -6,6 +6,7 @@
 : ${TIMING:=4}
 : ${TOP_PORTS:=20}
 : ${OPEN:=false}
+: ${DO_PING:=true}
 
 ########################################
 # Determine values in prep for scanning

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -232,9 +232,11 @@ grepable_output(){
 normal_output(){
 	printf "Scan report for %s (%s):\n" $name $host
 
+	# If we have a latency value, host is up
 	if [[ -n "$latency" ]]; then
 		printf "Host is up (%ss latency)\n" $latency
-	else
+	# Only report down if we haven't disabled ping
+	elif [[ "$DO_PING" = true ]]; then
 		printf "Host seems down\n"
 	fi
 
@@ -420,7 +422,13 @@ main(){
 
 	for host in ${LIVEHOSTS[@]}; do
 		name=$(revdns $host)
-		latency="$(latency $host)"
+		# Usually, the only reason ping will be disabled is because
+		# ICMP is being dropped/blocked. In this case, our latency
+		# method won't work either, so only attempt latency measure
+		# if we can ping. 
+		if [[ "$DO_PING" = true ]]; then
+			latency="$(latency $host)"
+		fi
 		portscan $host
 
 		# If we specify -o flag, only print results if one or more

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -9,7 +9,7 @@ ip2int(){
 }
 
 int2ip(){
-    local ui32=$1; shift
+    local ui32=$1
     local ip n
     for n in 1 2 3 4; do
         ip=$((ui32 & 0xff))${ip:+.}$ip
@@ -78,33 +78,32 @@ local list_type=$2
 local valid_targets
 
 # If there is a "-" in input, treat as IP range
-# FIXME: currently only handles 4th octet;
-#        add support for ranges in all 4 octets
 if [[ -n "$(grep -i - <<< $TARGET)" ]]; then
-	IFS='-' read start_ip end_oct4 <<< $TARGET
-	network=$(echo $start_ip | cut -d"." -f1,2,3)
-	end_ip=$network.$end_oct4
-	start_oct4=$(echo $start_ip | cut -d"." -f4)
-	# If the beginning and ending IPs specified are 
-	# valid, assign all addresses in range to TARGETS array
-	if valid_ip "$start_ip" && valid_ip "$end_ip"; then	
-		if [[ "$start_oct4" -lt "$end_oct4" ]]; then
-			for oct4 in $(seq $start_oct4 $end_oct4); do
-				valid_targets+=("$network.$oct4")
+	IFS=. read oct1 oct2 oct3 oct4 <<< $TARGET
+	# There probably isn't a need to scan class d/e 
+	# networks, so we could cap the 1st octet at 223;
+	# For the sake of simplicity, we use the same 
+	# validation check in all 4 octets, with max=255
+	oct1=("$(valid_octet $oct1)")
+	oct2=("$(valid_octet $oct2)")
+	oct3=("$(valid_octet $oct3)")
+	oct4=("$(valid_octet $oct4)")
+	for a in $oct1; do
+		for b in $oct2; do
+			for c in $oct3; do
+				for d in $oct4; do
+					valid_targets+=("$a"."$b"."$c"."$d")
+				done
 			done
-		else
-			if [[ -z "$i_file" ]]; then usage; fi
-		fi
-	else
-		if [[ -z "$i_file" ]]; then usage; fi
-	fi
+		done
+	done
 # If there is a "/" in the input, treat as CIDR
 elif [[ -n "$(grep -i / <<< $TARGET)" ]]; then
 	# Sanity check base IP specified is valid
 	if ! valid_ip "${TARGET%/*}"; then
 		if [[ -z "$i_file" ]]; then usage; fi
 	else
-		valid_targets+=("$(cidr2ip $TARGET)")
+		valid_targets+=($(cidr2ip $TARGET))
 	fi
 # Comma-separated list?
 elif  [[ -n "$(grep -i , <<< $TARGET)" ]]; then
@@ -378,11 +377,13 @@ main(){
 		TARGETS+=($(cidr2ip "$localip/$netCIDR"))
 	fi
 
+	num_targets="${#TARGETS[@]}"
+
 	if [[ "$DO_PING" = true ]]; then
 		if [ "$arp_warning" = true ]; then
 			printf "\n[-] ARP ping disabled as root may be required, [ -h | --help ] for more information"
 		fi
-		printf "\n[+] Sweeping for live hosts (%s%s%s)\n" $SWEEP_METHOD
+		printf "\n[+] Sweeping %s %s for live hosts (%s%s%s)\n" $num_targets $(plural $num_targets "target") $SWEEP_METHOD
 
 		LIVEHOSTS=($(pingsweep | sort -V | uniq))
 	else

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -152,38 +152,16 @@ banners(){
 	fi
 }
 
-# Check single TARGET for response before port scanning
-pingcheck(){
-	TARGET=$1
-	if [ "$SWEEP_METHOD" == "ICMP + ARP" ]; then
-		arping -c 1 -w 1 -I $default_interface $TARGET 2>/dev/null | tr \\n " " | awk '/1 from/ {print $2}' &
-	fi
-	# Added stderr redirection to catch ping warning for broadcast address
-	# Adding "-b" would enable pinging broadcast, but I doubt that's what we want
-	ping -c 1 -W 1 $TARGET 2>/dev/null | tr \\n " " | awk '/1 received/ {print $2}' &
-}
-
-# Ping multiple hosts
+# Ping each host in global TARGETS array
 pingsweep(){
-	if [ -n "$TARGETS" ]; then
-		for ip in ${TARGETS[@]}; do
-			pingcheck "$ip"
-		done;
-	else
-		# If user originally specified a target, 
-		# either via cli or file input, and none of the
-		# targets validated, we should let them know that
-		# rather than failing over to our default scan
-		if [[ -n "$TARGET" ]]; then
-			printf ""
-		# Default case - no user supplied targets
-		else
-			TARGETS+=($(cidr2ip "$localip/$netCIDR"))
-			for ip in ${TARGETS[@]}; do
-				pingcheck "$ip"
-			done;
+	for ip in ${TARGETS[@]}; do
+		if [ "$SWEEP_METHOD" == "ICMP + ARP" ]; then
+			arping -c 1 -w 1 -I $default_interface $ip 2>/dev/null | tr \\n " " | awk '/1 from/ {print $2}' &
 		fi
-	fi
+		# Added stderr redirection to catch ping warning for broadcast address
+		# Adding "-b" would enable pinging broadcast, but I doubt that's what we want
+		ping -c 1 -W 1 $ip 2>/dev/null | tr \\n " " | awk '/1 received/ {print $2}' &
+	done
 }
 
 # Scan ports
@@ -368,20 +346,45 @@ main(){
 		printf "Target:\t\t\t%s\n" "$TARGET"
 	fi
 
-	if [ "$arp_warning" = true ]; then
-		printf "\n[-] ARP ping disabled as root may be required, [ -h | --help ] for more information"
+	# If user hasn't supplied any targets, handle default
+	# case by assigning localip range to TARGETS array
+	# NOTE: test for $i_file to avoid rolling into a default
+	#       network scan in cases where the input file 
+	#       contained no valid/live hosts
+	if [[ -z "$TARGETS" ]] && [[ -z "$i_file" ]]; then
+		TARGETS+=($(cidr2ip "$localip/$netCIDR"))
 	fi
 
-	printf "\n[+] Sweeping for live hosts (%s%s%s)\n" $SWEEP_METHOD
+	if [[ "$DO_PING" = true ]]; then
+		if [ "$arp_warning" = true ]; then
+			printf "\n[-] ARP ping disabled as root may be required, [ -h | --help ] for more information"
+		fi
+		printf "\n[+] Sweeping for live hosts (%s%s%s)\n" $SWEEP_METHOD
 
-	LIVEHOSTS=($(pingsweep | sort -V | uniq))
+		LIVEHOSTS=($(pingsweep | sort -V | uniq))
+	else
+		# In this case, we aren't pinging to populate a list
+		# of "live" hosts... just copy the TARGETS array to
+		# LIVEHOSTS and start port scanning that.
+		printf "\n[-] Host discovery disabled\n"
+		#printf "[*] Warning: This can potentially be very slow over large ranges of targets/ports\n"
+		#printf "[*] Note: Output for hosts with no open ports can be disabled with [ -o | --open ]\n"
+		LIVEHOSTS+=("${TARGETS[@]}")
+	fi
+
 	num_hosts=${#LIVEHOSTS[@]}
 
-	if [ "$num_hosts" -gt 0 ]; then
-		printf "[+] $num_hosts %s found\n[+] Beginning scan of %s total %s\n\n" $(plural $num_hosts host) $num_ports $(plural $num_ports port)
-		portscan | sort -V | uniq
-	else
+	if [ "$num_hosts" -eq 0 ]; then
 		printf "[+] No responsive hosts found\n\n"
+	else
+		# Adjust stdout verbiage depending on whether host
+		# discovery is enabled or disabled
+		if [[ "$DO_PING" = true ]]; then
+			printf "[+] $num_hosts %s found\n" $(plural $num_hosts host) 
+		fi
+			printf "[+] Beginning scan of %s %s on %s %s\n\n" $num_ports $(plural $num_ports "port") $num_hosts $(plural $num_hosts "target")
+			portscan | sort -V | uniq
+		
 	fi
 
 	datestart_file=$(date --date @"$(( $START_SCRIPT / 1000 ))" "+%c")

--- a/lib/validations.sh
+++ b/lib/validations.sh
@@ -28,6 +28,20 @@ valid_ip(){
     return $stat
 }
 
+valid_octet(){
+    octet=$1 
+    if [[ -n "$(grep -i - <<< $octet)" ]]; then
+        IFS='-' read start_octet end_octet <<< $octet
+        if (( 0 < $start_octet < 255 )) && (( 1 < $end_octet <= 255 )) && (( $start_octet <= $end_octet )); then
+            printf "$(seq $start_octet $end_octet)"
+        else
+            if [[ -z "$i_file" ]]; then usage; fi
+        fi
+    else
+        printf "$octet"
+    fi
+}
+
 # Validate timing flag is in range
 valid_timing(){
 	if ! [ "$1" -eq "$1" ] 2>/dev/null; then

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ usage() {
 	printf "No nmap only bash /dev/tcp go brrrrrrrrrrrrrrrrr
 Usage:  %s
 	[ -b | --banner ]         Attempt to grab banner during port scanning
-	[ -e | --exclude ]        Exclude targets from scan
+	[ -e | --exclude]        Exclude targets from scan
 	[ -h | --help ]           Show this help message and exit.
 	[ -o | --open ]           Only show targets with open ports
 	[ -p | --ports <PORTS> ]  Comma-separated list or range of integers up to 65535.
@@ -32,6 +32,7 @@ Usage:  %s
 	[ -xL <file> ]            Exclude list of targets from input file
 	[ -oN <file> ]            Normal output: similar to interactive output
 	[ -oG <file> ]            Grepable output: comma-delimited, each host on a single line
+	[ -Pn ]                   No ping; Skip host discovery and go directly to port scanning
 	<x.x.x.[x|x-y|x/24]>      Target IP (optional), as single, range, or CIDR\n\n" $PROGNAME
 	exit 0
 }

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ usage() {
 	printf "No nmap only bash /dev/tcp go brrrrrrrrrrrrrrrrr
 Usage:  %s
 	[ -b | --banner ]         Attempt to grab banner during port scanning
-	[ -e | --exclude]        Exclude targets from scan
+	[ -e | --exclude ]        Exclude targets from scan
 	[ -h | --help ]           Show this help message and exit.
 	[ -o | --open ]           Only show targets with open ports
 	[ -p | --ports <PORTS> ]  Comma-separated list or range of integers up to 65535.


### PR DESCRIPTION
Covers issue #28 
Note: added (commented out) potential warning message for stdout to highlight the fact that skipping host discovery really slows scanning down significantly in many cases. It is unavoidable in cases where ICMP is being dropped/blocked, but noteworthy nonetheless. Users probably don't want to enable this flag unless they really need to. 