### PR TITLE
Added support for https banners using OpenSSL

### DIFF
--- a/bashscan.sh
+++ b/bashscan.sh
@@ -311,9 +311,18 @@ banners(){
 		# For http services, we usually need to echo in
 		# a formatted request in order to get a server
 		# banner in response; 
-		"http" | "https" | "http-proxy" |  "http-alt" | "https-alt" )
+		"http" | "http-proxy" |  "http-alt" )
 			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
-			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -iav "mismatch" | grep -i "server:")
+			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -i "server:")
+			;;
+		# The target may not have OpenSSL library available,
+		# but handling a TLS connection in pure BASH is a 
+		# rather steep hill to climb for now;
+		# We can also grab the server cert here and add it 
+		# to the output if that is desired.
+		"https" | "https-alt" )
+			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
+			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
 			;;
 		*)
 			conn=""

--- a/bashscan.sh
+++ b/bashscan.sh
@@ -195,7 +195,7 @@ cidr2network(){
 # Input: hostname
 # Output: IP
 resolve_host(){
-	local ip 
+	local ip=""
 	local host=$1
 	if test $(which dig); then
 		ip=$(dig +search +short $host)
@@ -275,7 +275,7 @@ else
 	# Is this a valid hostname?
 	check_hostname=$(resolve_host $TARGET)
 	if valid_ip $check_hostname; then
-		TARGET="$check_hostname"
+		valid_targets+="$check_hostname"
 	elif valid_ip $TARGET; then
 		valid_targets+=("$TARGET")
 	# If all checks above fail, treat as invalid input
@@ -323,6 +323,10 @@ banners(){
 		"https" | "https-alt" )
 			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
 			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
+			;;
+		"smtps" | "submission" )
+			conn=""
+			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null")
 			;;
 		*)
 			conn=""

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -173,9 +173,18 @@ banners(){
 		# For http services, we usually need to echo in
 		# a formatted request in order to get a server
 		# banner in response; 
-		"http" | "https" | "http-proxy" |  "http-alt" | "https-alt" )
+		"http" | "http-proxy" |  "http-alt" )
 			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
-			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -iav "mismatch" | grep -i "server:")
+			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -i "server:")
+			;;
+		# The target may not have OpenSSL library available,
+		# but handling a TLS connection in pure BASH is a 
+		# rather steep hill to climb for now;
+		# We can also grab the server cert here and add it 
+		# to the output if that is desired.
+		"https" | "https-alt" )
+			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
+			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
 			;;
 		*)
 			conn=""

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -175,22 +175,25 @@ banners(){
 		# a formatted request in order to get a server
 		# banner in response; 
 		"http" | "http-proxy" |  "http-alt" )
-			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
-			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -i "server:")
+			conn="'HEAD / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
+			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -i "server:" | cut -d" " -f2-)
 			;;
-		# The target may not have OpenSSL library available,
+		# Our script host may not have OpenSSL library available,
 		# but handling a TLS connection in pure BASH is a 
 		# rather steep hill to climb for now;
 		# We can also grab the server cert here and add it 
 		# to the output if that is desired.
 		"https" | "https-alt" )
-			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
-			banner=$(timeout $limit bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
+			conn="'HEAD / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
+			banner=$(timeout $limit bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:" | cut -d" " -f2-)
 			;;
 		"smtps" | "submission" | "pop3s" )
 			conn=""
 			banner=$(timeout $limit bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | head -n 1)
 			;;
+		# DNS servers don't have banners per se, but we can
+		# attempt to fingerprint. This is very basic, but can
+		# get more complex if we go into more fingerprinting
 		"domain" )
 			banner=$(dig version.bind CHAOS TXT @$host 2>/dev/null | grep ^version.bind | cut -d$'\t' -f6)
 		;;

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -164,8 +164,9 @@ banners(){
 	host="$1"
 	port="$2"
 
+	limit="0.5s"
 	service=$(cat lib/nmap-services | grep -w "${port}/tcp" | cut -d" " -f1)
-
+    
 	# Eventually, this case statement may scale to a 
 	# point where a different approach is more readable; 
 	# For now, this should work as a poc. 
@@ -184,15 +185,18 @@ banners(){
 		# to the output if that is desired.
 		"https" | "https-alt" )
 			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
-			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
+			banner=$(timeout $limit bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
 			;;
-		"smtps" | "submission" )
+		"smtps" | "submission" | "pop3s" )
 			conn=""
-			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null")
+			banner=$(timeout $limit bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | head -n 1)
 			;;
+		"domain" )
+			banner=$(dig version.bind CHAOS TXT @$host 2>/dev/null | grep ^version.bind | cut -d$'\t' -f6)
+		;;
 		*)
 			conn=""
-			banner=$(timeout 0.5s bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -iav "mismatch" | cut -d$'\n' -f1 | tr "\\r" " ")
+			banner=$(timeout $limit bash -c "exec 3<>/dev/tcp/$host/$port; echo -e $conn>&3; cat<&3" | grep -iav "mismatch" | cut -d$'\n' -f1 | tr "\\r" " ")
 			;;
 	esac
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -57,7 +57,7 @@ cidr2network(){
 # Input: hostname
 # Output: IP
 resolve_host(){
-	local ip 
+	local ip=""
 	local host=$1
 	if test $(which dig); then
 		ip=$(dig +search +short $host)
@@ -137,7 +137,7 @@ else
 	# Is this a valid hostname?
 	check_hostname=$(resolve_host $TARGET)
 	if valid_ip $check_hostname; then
-		TARGET="$check_hostname"
+		valid_targets+="$check_hostname"
 	elif valid_ip $TARGET; then
 		valid_targets+=("$TARGET")
 	# If all checks above fail, treat as invalid input
@@ -185,6 +185,10 @@ banners(){
 		"https" | "https-alt" )
 			conn="'GET / HTTP/1.1\r\nhost: ' $host '\r\n\r\n'"
 			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null" | grep -i "server:")
+			;;
+		"smtps" | "submission" )
+			conn=""
+			banner=$(timeout 0.5s bash -c "echo -ne $conn | openssl s_client -quiet -connect $host:$port 2>/dev/null")
 			;;
 		*)
 			conn=""


### PR DESCRIPTION
The s_client method should also work for other TLS-type connections, such as smtp (using STARTTLS), etc.