### PR TITLE
Fix invalid pidstate test

### DIFF
--- a/bashscan.sh
+++ b/bashscan.sh
@@ -576,7 +576,7 @@ ParallelExec() {
         for pid in "${pidsArray[@]}"; do
             # Handle uninterruptible sleep state or zombies by ommiting them from running process array (How to kill that is already dead ? :)
             if kill -0 $pid > /dev/null 2>&1; then
-                pidState=$(ps -p$pid -o state= 2 > /dev/null)
+                pidState=$(ps -p$pid -o state= 2>/dev/null)
                 if [ "$pidState" != "D" ] && [ "$pidState" != "Z" ]; then
                     newPidsArray+=($pid)
                 fi


### PR DESCRIPTION
the output of the ps command was always empty because stdout instead
of stderr was redirected to /dev/null.

`execsnoop` revealed:
```
ps               83130  83129    0 /usr/bin/ps -p83070 -o state= 2
ps               83132  83131    0 /usr/bin/ps -p83072 -o state= 2
ps               83134  83133    0 /usr/bin/ps -p83080 -o state= 2
```
^^^ in addition to the selected PID, PID 2 was checked 